### PR TITLE
V4 compatibility

### DIFF
--- a/core/template/dashboard/digicode.html
+++ b/core/template/dashboard/digicode.html
@@ -1,5 +1,5 @@
 <div class="eqLogic-widget eqLogic digicode" style="width: 280px;height: 360px;padding : 0px;border: #border#;border-radius: #border-radius#;background-color: #background-color#;color: #color#;#style#;" data-eqLogic_id="#id#" data-eqLogic_uid="#uid#" data-version="#version#">
-  <span class="spanConfiguration" style="position : absolute;bottom: 3px;right: 35px;font-size : 2.5em;"><i class="fa fa-gear" title="Configuration utilisateur"></i></span>
+  <span class="spanConfiguration" style="position : absolute;bottom: 3px;right: 35px;font-size : 2.5em;"><i class="fas fa-cog" title="Configuration utilisateur"></i></span>
   <span class="spanEtatFenetres"></span>
   <span class="spanEtatPortes"></span>
 

--- a/core/template/dplan/digicode.html
+++ b/core/template/dplan/digicode.html
@@ -1,5 +1,5 @@
 <div class="eqLogic-widget eqLogic digicode" style="width: 280px;height: 360px;padding : 0px;border: #border#;border-radius: #border-radius#;background-color: #background-color#;color: #color#;#style#;" data-eqLogic_id="#id#" data-eqLogic_uid="#uid#" data-version="#version#">
-  <span class="spanConfiguration" style="position : absolute;bottom: 3px;right: 35px;font-size : 2.5em;"><i class="fa fa-gear" title="Configuration utilisateur"></i></span>
+  <span class="spanConfiguration" style="position : absolute;bottom: 3px;right: 35px;font-size : 2.5em;"><i class="fas fa-cog" title="Configuration utilisateur"></i></span>
   <span class="spanEtatFenetres"></span>
   <span class="spanEtatPortes"></span>
 

--- a/desktop/js/digicode.js
+++ b/desktop/js/digicode.js
@@ -56,10 +56,10 @@ if (_cmd.configuration.type !== 'cmdwiget') {
     tr += '</td>';
     tr += '<td>';
     if (is_numeric(_cmd.id)) {
-        tr += '<a class="btn btn-default btn-xs cmdAction" data-action="configure"><i class="fa fa-cogs"></i></a> ';
-        tr += '<a class="btn btn-default btn-xs cmdAction" data-action="test"><i class="fa fa-rss"></i> {{Tester}}</a>';
+        tr += '<a class="btn btn-default btn-xs cmdAction" data-action="configure"><i class="fas fa-cogs"></i></a> ';
+        tr += '<a class="btn btn-default btn-xs cmdAction" data-action="test"><i class="fas fa-rss"></i> {{Tester}}</a>';
     }
-    tr += '<i class="fa fa-minus-circle pull-right cmdAction cursor" data-action="remove"></i>';
+    tr += '<i class="fas fa-minus-circle pull-right cmdAction cursor" data-action="remove"></i>';
     tr += '</td>';
     tr += '</tr>';
 }

--- a/desktop/modal/modal.digicode.php
+++ b/desktop/modal/modal.digicode.php
@@ -57,8 +57,8 @@ foreach ($digicode->getCmd('info') as $cmd) {
         echo $cmd->getConfiguration('userCode');
         echo '</td>';
         echo '<td>';
-        echo '<a class="btn btn-success bt_Modify btn-xs" data-id="' . $cmd->getid() . '"><i class="fa fa-gear"></i></a></center>';
-        echo '<a class="btn btn-danger bt_Remove btn-xs" data-id="' . $cmd->getid() . '"><i class="fa fa-trash-o"></i></a></center>';
+        echo '<a class="btn btn-success bt_Modify btn-xs" data-id="' . $cmd->getid() . '"><i class="fas fa-cog"></i></a></center>';
+        echo '<a class="btn btn-danger bt_Remove btn-xs" data-id="' . $cmd->getid() . '"><i class="maison-poubelle"></i></a></center>';
         echo '</td>';
         echo '</tr>';
     }

--- a/desktop/php/digicode.php
+++ b/desktop/php/digicode.php
@@ -11,7 +11,7 @@ $eqLogics = eqLogic::byType($plugin->getId());
     <div class="col-lg-2 col-md-3 col-sm-4">
         <div class="bs-sidebar">
             <ul id="ul_eqLogic" class="nav nav-list bs-sidenav">
-                <a class="btn btn-default eqLogicAction" style="width : 100%;margin-top : 5px;margin-bottom: 5px;" data-action="add"><i class="fa fa-plus-circle"></i> {{Ajouter un digicode}}</a>
+                <a class="btn btn-default eqLogicAction" style="width : 100%;margin-top : 5px;margin-bottom: 5px;" data-action="add"><i class="fas fa-plus-circle"></i> {{Ajouter un digicode}}</a>
                 <li class="filter" style="margin-bottom: 5px;"><input class="filter form-control input-sm" placeholder="{{Rechercher}}" style="width: 100%"/></li>
                 <?php
                 foreach ($eqLogics as $eqLogic) {
@@ -25,20 +25,20 @@ $eqLogics = eqLogic::byType($plugin->getId());
 
     <div class="col-lg-10 col-md-9 col-sm-8 eqLogicThumbnailDisplay" style="border-left: solid 1px #EEE; padding-left: 25px;">
         <legend>{{Mes digicode}}</legend>
-        <legend><i class="fa fa-cog"></i>  {{Gestion}}</legend>
+        <legend><i class="fas fa-cog"></i>  {{Gestion}}</legend>
         <div class="eqLogicThumbnailContainer">
             <div class="cursor eqLogicAction" data-action="add" style="text-align: center; background-color : #ffffff; height : 120px;margin-bottom : 10px;padding : 5px;border-radius: 2px;width : 160px;margin-left : 10px;" >
-                <i class="fa fa-plus-circle" style="font-size : 6em;color:#94ca02;"></i>
+                <i class="fas fa-plus-circle" style="font-size : 6em;color:#94ca02;"></i>
                 <br>
                 <span style="font-size : 1.1em;position:relative; top : 23px;word-break: break-all;white-space: pre-wrap;word-wrap: break-word;color:#94ca02">{{Ajouter}}</span>
             </div>
             <div class="cursor eqLogicAction" data-action="gotoPluginConf" style="text-align: center; background-color : #ffffff; height : 120px;margin-bottom : 10px;padding : 5px;border-radius: 2px;width : 160px;margin-left : 10px;">
-                <i class="fa fa-wrench" style="font-size : 6em;color:#767676;"></i>
+                <i class="fas fa-wrench" style="font-size : 6em;color:#767676;"></i>
                 <br>
                 <span style="font-size : 1.1em;position:relative; top : 15px;word-break: break-all;white-space: pre-wrap;word-wrap: break-word;color:#767676">{{Configuration}}</span>
             </div>
         </div>
-        <legend><i class="fa fa-table"></i> {{Mes digicodes}}</legend>
+        <legend><i class="fas fa-table"></i> {{Mes digicodes}}</legend>
         <div class="eqLogicThumbnailContainer">
             <?php
             foreach ($eqLogics as $eqLogic) {
@@ -54,13 +54,13 @@ $eqLogics = eqLogic::byType($plugin->getId());
     </div>
 
     <div class="col-lg-10 col-md-9 col-sm-8 eqLogic" style="border-left: solid 1px #EEE; padding-left: 25px;display: none;">
-        <a class="btn btn-success eqLogicAction pull-right" data-action="save"><i class="fa fa-check-circle"></i> {{Sauvegarder}}</a>
-        <a class="btn btn-danger eqLogicAction pull-right" data-action="remove"><i class="fa fa-minus-circle"></i> {{Supprimer}}</a>
-        <a class="btn btn-default eqLogicAction pull-right" data-action="configure"><i class="fa fa-cogs"></i> {{Configuration avancée}}</a>
+        <a class="btn btn-success eqLogicAction pull-right" data-action="save"><i class="fas fa-check-circle"></i> {{Sauvegarder}}</a>
+        <a class="btn btn-danger eqLogicAction pull-right" data-action="remove"><i class="fas fa-minus-circle"></i> {{Supprimer}}</a>
+        <a class="btn btn-default eqLogicAction pull-right" data-action="configure"><i class="fas fa-cogs"></i> {{Configuration avancée}}</a>
         <ul class="nav nav-tabs" role="tablist">
-            <li role="presentation"><a href="#" class="eqLogicAction" aria-controls="home" role="tab" data-toggle="tab" data-action="returnToThumbnailDisplay"><i class="fa fa-arrow-circle-left"></i></a></li>
-            <li role="presentation" class="active"><a href="#eqlogictab" aria-controls="home" role="tab" data-toggle="tab"><i class="fa fa-tachometer"></i> {{Equipement}}</a></li>
-            <li role="presentation"><a href="#commandtab" aria-controls="profile" role="tab" data-toggle="tab"><i class="fa fa-list-alt"></i> {{Commandes}}</a></li>
+            <li role="presentation"><a href="#" class="eqLogicAction" aria-controls="home" role="tab" data-toggle="tab" data-action="returnToThumbnailDisplay"><i class="fas fa-arrow-circle-left"></i></a></li>
+            <li role="presentation" class="active"><a href="#eqlogictab" aria-controls="home" role="tab" data-toggle="tab"><i class="fas fa-tachometer-alt"></i> {{Equipement}}</a></li>
+            <li role="presentation"><a href="#commandtab" aria-controls="profile" role="tab" data-toggle="tab"><i class="fas fa-list-alt"></i> {{Commandes}}</a></li>
         </ul>
         <div class="tab-content" style="height:calc(100% - 50px);overflow:auto;overflow-x: hidden;">
             <div role="tabpanel" class="tab-pane active" id="eqlogictab">
@@ -80,7 +80,7 @@ $eqLogics = eqLogic::byType($plugin->getId());
                                 <select id="sel_object" class="eqLogicAttr form-control" data-l1key="object_id">
                                     <option value="">{{Aucun}}</option>
                                     <?php
-                                    foreach (object::all() as $object) {
+                                    foreach (jeeObject::all() as $object) {
                                         echo '<option value="' . $object->getId() . '">' . $object->getName() . '</option>';
                                     }
                                     ?>
@@ -111,7 +111,7 @@ $eqLogics = eqLogic::byType($plugin->getId());
                             <div class="input-group">
                                 <input type="text" class="eqLogicAttr form-control" data-l1key="configuration" data-l2key="digicodeCmdStatus"/>
                                 <span class="input-group-btn">
-                                    <a class="btn btn-default listCmdInfo"><i class="fa fa-list-alt"></i></a>
+                                    <a class="btn btn-default listCmdInfo"><i class="fas fa-list-alt"></i></a>
                                 </span>
                             </div>
                         </div>
@@ -120,7 +120,7 @@ $eqLogics = eqLogic::byType($plugin->getId());
                             <div class="input-group">
                                 <input type="text" class="eqLogicAttr form-control" data-l1key="configuration" data-l2key="digicodeCmdTotal"/>
                                 <span class="input-group-btn">
-                                    <a class="btn btn-default listCmdActionOther"><i class="fa fa-list-alt"></i></a>
+                                    <a class="btn btn-default listCmdActionOther"><i class="fas fa-list-alt"></i></a>
                                 </span>
                             </div>
                         </div>
@@ -129,7 +129,7 @@ $eqLogics = eqLogic::byType($plugin->getId());
                             <div class="input-group">
                                 <input type="text" class="eqLogicAttr form-control" data-l1key="configuration" data-l2key="digicodeCmdPartiel"/>
                                 <span class="input-group-btn">
-                                    <a class="btn btn-default listCmdActionOther"><i class="fa fa-list-alt"></i></a>
+                                    <a class="btn btn-default listCmdActionOther"><i class="fas fa-list-alt"></i></a>
                                 </span>
                             </div>
                         </div>
@@ -138,7 +138,7 @@ $eqLogics = eqLogic::byType($plugin->getId());
                             <div class="input-group">
                                 <input type="text" class="eqLogicAttr form-control" data-l1key="configuration" data-l2key="digicodeCmdDesactivation"/>
                                 <span class="input-group-btn">
-                                    <a class="btn btn-default listCmdActionOther"><i class="fa fa-list-alt"></i></a>
+                                    <a class="btn btn-default listCmdActionOther"><i class="fas fa-list-alt"></i></a>
                                 </span>
                             </div>
                         </div>
@@ -147,7 +147,7 @@ $eqLogics = eqLogic::byType($plugin->getId());
                             <div class="input-group">
                                 <input type="text" class="eqLogicAttr form-control" data-l1key="configuration" data-l2key="digicodeEtatPortes"/>
                                 <span class="input-group-btn">
-                                    <a class="btn btn-default listCmdInfo"><i class="fa fa-list-alt"></i></a>
+                                    <a class="btn btn-default listCmdInfo"><i class="fas fa-list-alt"></i></a>
                                 </span>
                             </div>
                         </div>
@@ -162,7 +162,7 @@ $eqLogics = eqLogic::byType($plugin->getId());
                             <div class="input-group">
                                 <input type="text" class="eqLogicAttr form-control" data-l1key="configuration" data-l2key="digicodeEtatFenetres"/>
                                 <span class="input-group-btn">
-                                    <a class="btn btn-default listCmdInfo"><i class="fa fa-list-alt"></i></a>
+                                    <a class="btn btn-default listCmdInfo"><i class="fas fa-list-alt"></i></a>
                                 </span>
                             </div>
                         </div>
@@ -185,7 +185,7 @@ $eqLogics = eqLogic::byType($plugin->getId());
 
 
             <div role="tabpanel" class="tab-pane" id="commandtab">
-                <a class="btn btn-success btn-sm cmdAction pull-right" data-action="add" style="margin-top:5px;"><i class="fa fa-plus-circle"></i> {{Commandes}}</a><br/><br/>
+                <a class="btn btn-success btn-sm cmdAction pull-right" data-action="add" style="margin-top:5px;"><i class="fas fa-plus-circle"></i> {{Commandes}}</a><br/><br/>
                 <table id="table_cmd" class="table table-bordered table-condensed">
                     <thead>
                         <tr>


### PR DESCRIPTION
Bonjour,
Après avoir lu des messages des utilisateurs de ce plugin sur le forum Communautaire https://community.jeedom.com/t/digicode-et-v4/7198/17 j'ai parcouru le code et fait des modifications pour améliorer la compatibilité avec Jeedom V4 et PHP 7.3. En gros c'est la modification des icônes FontAwesome (j'ai tâché de trouver un bon équivalent quand l'icône n'est plus dispo en version non pro FA5 comme trash-o) et surtout le remplacement de la classe object:: par jeeObject:: sinon  çà plante avec PHP 7.3.
Note bien que c'est pour rendre service, je n'utilise pas ce plugin mais je l'ai installé et çà semble fonctionner comme ta doc l'indique, toutefois il serait préférable que tu vérifie si tu le peux.
Cordialement. Jean-Michel Védrine (développeur des plugins Sure PetCare Elm Touch et KRoomba)